### PR TITLE
Refactor estateguru and mintos parser

### DIFF
--- a/config/estateguru.yml
+++ b/config/estateguru.yml
@@ -1,0 +1,13 @@
+---
+type_regex: !!map
+  deposit: "^Einzahlung.*"
+  withdraw: "^Auszahlung.*"
+  interest: "(^Empfehlungsbonus.*)|(^Zins.*)|(^Sondervergütung.*)"
+
+csv_fieldnames: !!map
+  booking_date: 'Zahlungsdatum'
+  booking_date_format: '%d/%m/%Y %H:%M'
+  booking_details: 'Projektname'
+  booking_id: 'UniqueId'
+  booking_type: 'Cashflow-Typ'
+  booking_value: 'Betrag'

--- a/config/mintos.yml
+++ b/config/mintos.yml
@@ -1,0 +1,13 @@
+---
+type_regex: !!map
+  deposit: "^Incoming client.*"
+  withdraw: "^Withdraw application.*"
+  interest: "(^Delayed interest.*)|(^Late payment.*)|(^Interest income.*)|(^Cashback.*)"
+
+csv_fieldnames:
+  booking_date: 'Date'
+  booking_date_format: '%Y-%m-%d %H:%M:%S'
+  booking_details: 'Details'
+  booking_id: 'Transaction ID'
+  booking_type: 'Details'
+  booking_value: 'Turnover'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+astroid==1.6.3
 attrs==17.4.0
 certifi==2018.4.16
 chardet==3.0.4
@@ -5,11 +6,17 @@ codacy-coverage==1.3.11
 colorama==0.3.9
 coverage==4.5.1
 idna==2.6
+isort==4.3.4
+lazy-object-proxy==1.3.1
+mccabe==0.6.1
 more-itertools==4.1.0
 pluggy==0.6.0
 py==1.5.3
+pylint==1.8.4
 pytest==3.5.1
 pytest-cov==2.5.1
 requests==2.18.4
+ruamel.yaml==0.15.37
 six==1.11.0
 urllib3==1.22
+wrapt==1.10.11

--- a/src/base_parser.py
+++ b/src/base_parser.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+Module for a base peer to peer loan account statement parser
+
+Copyright 2018-04-29 ChrisRBe
+"""
+import codecs
+import csv
+import logging
+import os
+
+from datetime import datetime
+from .portfolio_performance_writer import PP_FIELDNAMES
+
+
+class BaseParser(object):
+    """
+    Implementation of a base p2p account statement parser
+    """
+    def __init__(self):
+        """
+        Constructor for BaseParser
+        """
+        self._account_statement_file = None
+        self.output_list = []
+
+        self.booking_date = ''
+        self.booking_date_format = ''
+        self.booking_details = ''
+        self.booking_id = ''
+        self.booking_type = ''
+        self.booking_value = ''
+
+        self.relevant_invest_regex = None
+        self.relevant_payment_regex = None
+        self.relevant_income_regex = None
+
+    @property
+    def account_statement_file(self):
+        """account statement file property"""
+        return self._account_statement_file
+
+    @account_statement_file.setter
+    def account_statement_file(self, value):
+        """account statement file property setter"""
+        self._account_statement_file = value
+
+    def parse_account_statement(self):
+        """
+        read a Estateguru account statement csv file and filter the content according to the defined strings
+
+        :return:
+        """
+        if os.path.exists(self._account_statement_file):
+            with codecs.open(self._account_statement_file, 'r', encoding='utf-8') as infile:
+                dialect = csv.Sniffer().sniff(infile.readline())
+                infile.seek(0)
+                account_statement = csv.DictReader(infile, dialect=dialect)
+                for statement in account_statement:
+                    if self.relevant_income_regex.match(statement[self.booking_type]):
+                        category = "Zinsen"
+                    elif self.relevant_invest_regex.match(statement[self.booking_type]):
+                        category = 'Einlage'
+                    elif self.relevant_payment_regex.match(statement[self.booking_type]):
+                        category = 'Entnahme'
+                    else:
+                        logging.debug(statement)
+                        continue
+
+                    booking_date = datetime.strptime(statement[self.booking_date], self.booking_date_format)
+                    note = "{id}: {details}".format(id=statement[self.booking_id],
+                                                    details=statement[self.booking_details])
+
+                    formatted_account_entry = {PP_FIELDNAMES[0]: booking_date.date(),
+                                               PP_FIELDNAMES[1]: statement[self.booking_value].replace('.', ','),
+                                               PP_FIELDNAMES[2]: category,
+                                               PP_FIELDNAMES[3]: note}
+                    self.output_list.append(formatted_account_entry)
+        else:
+            logging.error("Account statement file {} does not exist.".format(self.account_statement_file))
+        return self.output_list

--- a/src/estateguru_parser.py
+++ b/src/estateguru_parser.py
@@ -4,70 +4,27 @@ Module for the Estateguru account statement parser
 
 Copyright 2018-04-30 ChrisRBe
 """
-import codecs
-import csv
-import logging
-import os
 import re
 
-from datetime import datetime
-from .portfolio_performance_writer import PP_FIELDNAMES
+from .base_parser import BaseParser
 
 
-class EstateguruParser(object):
+class EstateguruParser(BaseParser):
     """
     Implementation for the Estateguru account statement parser
     """
     def __init__(self):
         """
-        Constructor for MintosParser
+        Constructor for EstateguruParser
         """
-        self._account_statement_file = None
-        self.output_list = []
+        super().__init__()
         self.relevant_invest_regex = re.compile("^Einzahlung.*")
         self.relevant_payment_regex = re.compile("^Auszahlung.*")
         self.relevant_income_regex = re.compile("^Empfehlungsbonus.*|^Zins.*|^Sondervergütung.*")
 
-    @property
-    def account_statement_file(self):
-        """account statement file property"""
-        return self._account_statement_file
-
-    @account_statement_file.setter
-    def account_statement_file(self, value):
-        """account statement file property setter"""
-        self._account_statement_file = value
-
-    def parse_account_statement(self):
-        """
-        read a Estateguru account statement csv file and filter the content according to the defined strings
-
-        :return:
-        """
-        if os.path.exists(self._account_statement_file):
-            with codecs.open(self._account_statement_file, 'r', encoding='utf-8') as infile:
-                dialect = csv.Sniffer().sniff(infile.readline())
-                infile.seek(0)
-                account_statement = csv.DictReader(infile, dialect=dialect)
-                for statement in account_statement:
-                    category = ''
-                    if self.relevant_income_regex.match(statement['Cashflow-Typ']):
-                        category = "Zinsen"
-                    elif self.relevant_invest_regex.match(statement['Cashflow-Typ']):
-                        category = 'Einlage'
-                    elif self.relevant_payment_regex.match(statement['Cashflow-Typ']):
-                        category = 'Entnahme'
-                    else:
-                        logging.debug(statement)
-                        continue
-
-                    date = datetime.strptime(statement['Zahlungsdatum'], "%d/%m/%Y %H:%M")
-                    note = "{id}: {details}".format(id=statement['UniqueId'], details=statement['Projektname'])
-
-                    formatted_account_entry = {PP_FIELDNAMES[0]: date.date(),
-                                               PP_FIELDNAMES[1]: statement['Betrag'].replace('.', ','),
-                                               PP_FIELDNAMES[2]: category,
-                                               PP_FIELDNAMES[3]: note}
-                    if category:
-                        self.output_list.append(formatted_account_entry)
-            return self.output_list
+        self.booking_date = 'Zahlungsdatum'
+        self.booking_date_format = '%d/%m/%Y %H:%M'
+        self.booking_details = 'Projektname'
+        self.booking_id = 'UniqueId'
+        self.booking_type = 'Cashflow-Typ'
+        self.booking_value = 'Betrag'

--- a/src/estateguru_parser.py
+++ b/src/estateguru_parser.py
@@ -4,12 +4,12 @@ Module for the Estateguru account statement parser
 
 Copyright 2018-04-30 ChrisRBe
 """
-import re
+import os
 
-from .base_parser import BaseParser
+from .p2p_account_statement_parser import PeerToPeerPlatformParser
 
 
-class EstateguruParser(BaseParser):
+class EstateguruParser(PeerToPeerPlatformParser):
     """
     Implementation for the Estateguru account statement parser
     """
@@ -18,13 +18,5 @@ class EstateguruParser(BaseParser):
         Constructor for EstateguruParser
         """
         super().__init__()
-        self.relevant_invest_regex = re.compile("^Einzahlung.*")
-        self.relevant_payment_regex = re.compile("^Auszahlung.*")
-        self.relevant_income_regex = re.compile("^Empfehlungsbonus.*|^Zins.*|^Sondervergütung.*")
 
-        self.booking_date = 'Zahlungsdatum'
-        self.booking_date_format = '%d/%m/%Y %H:%M'
-        self.booking_details = 'Projektname'
-        self.booking_id = 'UniqueId'
-        self.booking_type = 'Cashflow-Typ'
-        self.booking_value = 'Betrag'
+        self.config_file = os.path.join(os.path.dirname(__file__), os.pardir, 'config', 'estateguru.yml')

--- a/src/mintos_parser.py
+++ b/src/mintos_parser.py
@@ -4,16 +4,12 @@ Module for the Mintos account statement parser
 
 Copyright 2018-04-29 ChrisRBe
 """
-import csv
-import logging
-import os
 import re
 
-from datetime import datetime
-from .portfolio_performance_writer import PP_FIELDNAMES
+from .base_parser import BaseParser
 
 
-class MintosParser(object):
+class MintosParser(BaseParser):
     """
     Implementation for the Mintos account statement parser
     """
@@ -21,49 +17,14 @@ class MintosParser(object):
         """
         Constructor for MintosParser
         """
-        self._account_statement_file = None
-        self.output_list = []
+        super().__init__()
         self.relevant_invest_regex = re.compile("Incoming client")
+        self.relevant_payment_regex = re.compile("^Withdraw application.*")
         self.relevant_income_regex = re.compile("^Delayed interest.*|^Late payment.*|^Interest income.*|^Cashback.*")
 
-    @property
-    def account_statement_file(self):
-        """account statement file property"""
-        return self._account_statement_file
-
-    @account_statement_file.setter
-    def account_statement_file(self, value):
-        """account statement file property setter"""
-        self._account_statement_file = value
-
-    def parse_account_statement(self):
-        """
-        read a Mintos account statement csv file and filter the content according to the defined strings
-
-        :return:
-        """
-        if os.path.exists(self._account_statement_file):
-            with open(self._account_statement_file, 'r', newline='') as infile:
-                dialect = csv.Sniffer().sniff(infile.readline())
-                infile.seek(0)
-                account_statement = csv.DictReader(infile, dialect=dialect)
-                for statement in account_statement:
-                    category = ''
-                    if self.relevant_income_regex.match(statement['Details']):
-                        category = "Zinsen"
-                    elif self.relevant_invest_regex.match(statement['Details']):
-                        category = "Einlage"
-                    else:
-                        logging.debug(statement)
-                        continue
-
-                    date = datetime.strptime(statement['Date'], "%Y-%m-%d %H:%M:%S")
-                    note = "{id}: {details}".format(id=statement['Transaction ID'], details=statement['Details'])
-
-                    formatted_account_entry = {PP_FIELDNAMES[0]: date.date(),
-                                               PP_FIELDNAMES[1]: statement['Turnover'],
-                                               PP_FIELDNAMES[2]: category,
-                                               PP_FIELDNAMES[3]: note}
-                    if category:
-                        self.output_list.append(formatted_account_entry)
-            return self.output_list
+        self.booking_date = 'Date'
+        self.booking_date_format = '%Y-%m-%d %H:%M:%S'
+        self.booking_details = 'Details'
+        self.booking_id = 'Transaction ID'
+        self.booking_type = 'Details'
+        self.booking_value = 'Turnover'

--- a/src/mintos_parser.py
+++ b/src/mintos_parser.py
@@ -4,12 +4,12 @@ Module for the Mintos account statement parser
 
 Copyright 2018-04-29 ChrisRBe
 """
-import re
+import os
 
-from .base_parser import BaseParser
+from .p2p_account_statement_parser import PeerToPeerPlatformParser
 
 
-class MintosParser(BaseParser):
+class MintosParser(PeerToPeerPlatformParser):
     """
     Implementation for the Mintos account statement parser
     """
@@ -18,13 +18,5 @@ class MintosParser(BaseParser):
         Constructor for MintosParser
         """
         super().__init__()
-        self.relevant_invest_regex = re.compile("Incoming client")
-        self.relevant_payment_regex = re.compile("^Withdraw application.*")
-        self.relevant_income_regex = re.compile("^Delayed interest.*|^Late payment.*|^Interest income.*|^Cashback.*")
 
-        self.booking_date = 'Date'
-        self.booking_date_format = '%Y-%m-%d %H:%M:%S'
-        self.booking_details = 'Details'
-        self.booking_id = 'Transaction ID'
-        self.booking_type = 'Details'
-        self.booking_value = 'Turnover'
+        self.config_file = os.path.join(os.path.dirname(__file__), os.pardir, 'config', 'mintos.yml')

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -9,7 +9,6 @@ import csv
 import logging
 import os
 import re
-from builtins import property
 
 from datetime import datetime
 

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Module for a base peer to peer loan account statement parser
+Module for a generic peer to peer loan account statement parser.
 
 Copyright 2018-04-29 ChrisRBe
 """
@@ -8,20 +8,27 @@ import codecs
 import csv
 import logging
 import os
+import re
+from builtins import property
 
 from datetime import datetime
+
+from ruamel.yaml import YAML
+
 from .portfolio_performance_writer import PP_FIELDNAMES
 
 
-class BaseParser(object):
+class PeerToPeerPlatformParser(object):
     """
-    Implementation of a base p2p account statement parser
+    Implementation of a generic p2p investment platform account statement parser.
+    Actual configuration for the individual services is done via a yml config file.
     """
     def __init__(self):
         """
-        Constructor for BaseParser
+        Constructor for PeerToPeerPlatformParser
         """
         self._account_statement_file = None
+        self._config_file = None
         self.output_list = []
 
         self.booking_date = ''
@@ -45,6 +52,37 @@ class BaseParser(object):
         """account statement file property setter"""
         self._account_statement_file = value
 
+    @property
+    def config_file(self):
+        """config file property"""
+        return self._config_file
+
+    @config_file.setter
+    def config_file(self, value):
+        """config file property setter"""
+        self._config_file = value
+
+    def __parse_service_config(self):
+        """
+        Parse the YAML configuration file containing specific settings for the individual peer to peer loan provider
+
+        :return:
+        """
+        with open(self.config_file, 'r', encoding='utf-8') as ymlconfig:
+            yaml = YAML(typ='safe')
+            config = yaml.load(ymlconfig)
+
+            self.relevant_invest_regex = re.compile(config['type_regex']['deposit'])
+            self.relevant_payment_regex = re.compile(config['type_regex']['withdraw'])
+            self.relevant_income_regex = re.compile(config['type_regex']['interest'])
+
+            self.booking_date = config['csv_fieldnames']['booking_date']
+            self.booking_date_format = config['csv_fieldnames']['booking_date_format']
+            self.booking_details = config['csv_fieldnames']['booking_details']
+            self.booking_id = config['csv_fieldnames']['booking_id']
+            self.booking_type = config['csv_fieldnames']['booking_type']
+            self.booking_value = config['csv_fieldnames']['booking_value']
+
     def parse_account_statement(self):
         """
         read a Estateguru account statement csv file and filter the content according to the defined strings
@@ -52,6 +90,7 @@ class BaseParser(object):
         :return:
         """
         if os.path.exists(self._account_statement_file):
+            self.__parse_service_config()
             with codecs.open(self._account_statement_file, 'r', encoding='utf-8') as infile:
                 dialect = csv.Sniffer().sniff(infile.readline())
                 infile.seek(0)

--- a/src/test/test_base_parser.py
+++ b/src/test/test_base_parser.py
@@ -1,23 +1,39 @@
 # -*- coding: utf-8 -*-
 """
-Unit test for the mintos parser module
+Unit test for the base parser module
 
-Copyright 2018-04-29 ChrisRBe
+Copyright 2018-05-01 ChrisRBe
 """
 import datetime
 import os
+import re
 from unittest import TestCase
 
-from ..mintos_parser import MintosParser
+from ..base_parser import BaseParser
 
 
-class TestMintosParser(TestCase):
-    """Test case implementation for MintosParser"""
-
+class TestBaseParser(TestCase):
+    """Test case implementation for BaseParser"""
     def setUp(self):
         """test case setUp, run for each test case"""
-        self.mintos = MintosParser()
-        self.mintos.account_statement_file = os.path.join(os.path.dirname(__file__), 'testdata', 'mintos.csv')
+        self.base_parser = BaseParser()
+        self.base_parser.account_statement_file = os.path.join(os.path.dirname(__file__), 'testdata', 'mintos.csv')
+
+        self.base_parser.relevant_invest_regex = re.compile("Incoming client")
+        self.base_parser.relevant_payment_regex = re.compile("^Withdraw application.*")
+        self.base_parser.relevant_income_regex = re.compile("(^Delayed interest.*)|(^Late payment.*)|"
+                                                            "(^Interest income.*)|(^Cashback.*)")
+
+        self.base_parser.booking_date = 'Date'
+        self.base_parser.booking_date_format = '%Y-%m-%d %H:%M:%S'
+        self.base_parser.booking_details = 'Details'
+        self.base_parser.booking_id = 'Transaction ID'
+        self.base_parser.booking_type = 'Details'
+        self.base_parser.booking_value = 'Turnover'
+
+    def test_account_statement_file(self):
+        self.assertEqual(os.path.join(os.path.dirname(__file__), 'testdata', 'mintos.csv'),
+                         self.base_parser.account_statement_file)
 
     def test_parse_account_statement(self):
         """test parse_account_statement"""
@@ -56,4 +72,9 @@ class TestMintosParser(TestCase):
              'Typ': 'Entnahme',
              'Wert': '-20'}]
 
-        self.assertEqual(expected_statement, self.mintos.parse_account_statement())
+        self.assertEqual(expected_statement, self.base_parser.parse_account_statement())
+
+    def test_no_statement_file(self):
+        """test parse_account_statement with non existent file"""
+        self.base_parser.account_statement_file = os.path.join(os.path.dirname(__file__), 'not_existing.csv')
+        self.assertFalse(self.base_parser.parse_account_statement())

--- a/src/test/test_p2p_account_statement_parser.py
+++ b/src/test/test_p2p_account_statement_parser.py
@@ -1,39 +1,37 @@
 # -*- coding: utf-8 -*-
 """
-Unit test for the base parser module
+Unit test for the p2p account statement parser module
 
 Copyright 2018-05-01 ChrisRBe
 """
 import datetime
 import os
-import re
 from unittest import TestCase
 
-from ..base_parser import BaseParser
+from ..p2p_account_statement_parser import PeerToPeerPlatformParser
 
 
 class TestBaseParser(TestCase):
-    """Test case implementation for BaseParser"""
+    """Test case implementation for PeerToPeerPlatformParser"""
     def setUp(self):
         """test case setUp, run for each test case"""
-        self.base_parser = BaseParser()
+        self.base_parser = PeerToPeerPlatformParser()
         self.base_parser.account_statement_file = os.path.join(os.path.dirname(__file__), 'testdata', 'mintos.csv')
-
-        self.base_parser.relevant_invest_regex = re.compile("Incoming client")
-        self.base_parser.relevant_payment_regex = re.compile("^Withdraw application.*")
-        self.base_parser.relevant_income_regex = re.compile("(^Delayed interest.*)|(^Late payment.*)|"
-                                                            "(^Interest income.*)|(^Cashback.*)")
-
-        self.base_parser.booking_date = 'Date'
-        self.base_parser.booking_date_format = '%Y-%m-%d %H:%M:%S'
-        self.base_parser.booking_details = 'Details'
-        self.base_parser.booking_id = 'Transaction ID'
-        self.base_parser.booking_type = 'Details'
-        self.base_parser.booking_value = 'Turnover'
+        self.base_parser.config_file = os.path.join(os.path.dirname(__file__),
+                                                    os.pardir,
+                                                    os.pardir,
+                                                    'config',
+                                                    'mintos.yml')
 
     def test_account_statement_file(self):
+        """test account statement file property"""
         self.assertEqual(os.path.join(os.path.dirname(__file__), 'testdata', 'mintos.csv'),
                          self.base_parser.account_statement_file)
+
+    def test_config_file(self):
+        """test config file property"""
+        self.assertEqual(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'config', 'mintos.yml'),
+                         self.base_parser.config_file)
 
     def test_parse_account_statement(self):
         """test parse_account_statement"""

--- a/src/test/testdata/mintos.csv
+++ b/src/test/testdata/mintos.csv
@@ -14,3 +14,4 @@ Transaction ID;Date;Details;Turnover;Balance;Currency
 241699935;2018-01-25 23:30:00;Late payment fee income Loan ID: 1529173-01;0,001214211;8,460085025;EUR
 243559685;2018-01-29 11:23:17;Delayed interest income on rebuy Rebuy purpose: agreement_amendment Loan ID: 2198503-01;0,000342077;5,177127496;EUR
 260918485;2018-02-27 15:32:53;Cashback bonus;0,3;9,16072334;EUR
+115013710;2016-09-28 16:47:05;Withdraw application;-20;199,9539516;EUR


### PR DESCRIPTION
Both parser had duplicate code sections in the parse_account_statement
function. This change moved all of that into a common base class.
The specific classes only contribute config (csv fieldnames, regexes)
from now on.
Future modules should be easier to implement.

This should fix #25 