### PR TITLE
Update Bondora go&grow configs

### DIFF
--- a/config/bondora_go_grow.yml
+++ b/config/bondora_go_grow.yml
@@ -1,9 +1,9 @@
 ---
 type_regex: !!map
-  deposit: "(^TransferGoGrow.*)"
-  withdraw: "(^$)"
-  interest: "(^$)"
-  fee: "(^$)"
+  deposit: "(^TransferGoGrowMainRepaiment.*)"
+  withdraw: "(^TransferWithdraw*)"
+  interest: "(^TransferGoGrowInterestRepaiment$)"
+  fee: "(^GoGrowWithdrawalFee$)"
 
 csv_fieldnames:
   booking_date: 'TransferDate'

--- a/src/test/testdata/portfolio_performance__bondora_go_grow.csv
+++ b/src/test/testdata/portfolio_performance__bondora_go_grow.csv
@@ -1,2 +1,5 @@
 Datum,Wert,Buchungswährung,Typ,Notiz
-2019-01-02,-100,EUR,Einlage,: TransferGoGrow
+2020-01-20,"1,00",EUR,Einlage,NA: TransferGoGrowMainRepaiment
+2020-01-20,"1,00",EUR,Zinsen,NA: TransferGoGrowInterestRepaiment
+2020-01-20,"-1,00",EUR,Gebühren,NA: GoGrowWithdrawalFee
+2020-01-20,"-2,00",EUR,Entnahme,NA: TransferWithdraw


### PR DESCRIPTION
Superseeds #217 

Reverted the date formatting. This was done behind the scenes by my local script when reading the account statement. I now force-use the date-format provided by you to not have to alter the tests.

Not sure how other people do it - if there are more people in the future for which the default date format is different when having read in the `.xlsx` file it be worth changing the default here.

The main content of this PR is the addition of more expense and interest types.

