### PR TITLE
Aggregate transactions per command line parameter

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,15 @@
+version: "2"
+plugins:
+  fixme:
+    enabled: true
+  git-legal:
+    enabled: true
+  radon:
+    enabled: true
+    config:
+      threshold: "C"
+  sonar-python:
+    enabled: true
+    config:
+      tests_patterns:
+        - src/test/**

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,3 +13,5 @@ plugins:
     config:
       tests_patterns:
         - src/test/**
+exclude_patterns:
+  - "src/test/"

--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,4 @@ pytest = "==6.1.2"
 pytest-cov = "==2.10.1"
 
 [packages]
-"ruamel.yaml" = "==0.16.12"
+PyYAML = "==5.3.1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f3bad303efd4200ebee2/test_coverage)](https://codeclimate.com/github/ChrisRBe/PP-P2P-Parser/test_coverage)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
-
 ## Overview
 
 Application to read account statement files from different peer to peer lending sites,

--- a/parse-account-statements.py
+++ b/parse-account-statements.py
@@ -15,6 +15,13 @@ List of currently supported providers:
     - Swaper
     - Debitum Network
 
+Control the way how account statements are processed via the aggregate parameter:
+    - daily: Currently does not process the input data beyond making it Portfolio Performance compatible.
+    - monthly: This aggregates all bookings of the same type into one statement per type and month. Sets
+            the last day of the month as transaction date.
+
+Default behaviour for now is 'daily'.
+
 Copyright 2018-03-17 ChrisRBe
 """
 import argparse
@@ -44,13 +51,14 @@ def platform_factory(operator_name="mintos"):
         return None
 
 
-def main(infile, p2p_operator_name="mintos"):
+def main(infile, p2p_operator_name="mintos", aggregate="daily"):
     """
     Processes the provided input file with the rules defined for the given platform.
     Outputs a CSV file readable by Portfolio Performance
 
     :param infile: input file containing the account statements from a supported platform
     :param p2p_operator_name: name of the Peer-to-Peer lending platform, defaults to Mintos
+    :param aggregate: specifies the aggregation period. defaults to daily.
 
     :return: True, False if an error occurred.
     """
@@ -61,7 +69,7 @@ def main(infile, p2p_operator_name="mintos"):
     platform_parser = platform_factory(p2p_operator_name)
     if platform_parser:
         platform_parser.account_statement_file = infile
-        statement_list = platform_parser.parse_account_statement()
+        statement_list = platform_parser.parse_account_statement(aggregate=aggregate)
 
         if not statement_list:
             return False
@@ -90,11 +98,19 @@ if __name__ == "__main__":
         type=str,
         help="CSV file containing the downloaded data from the P2P site",
     )
+    ARG_PARSER.add_argument(
+        "--aggregate",
+        type=str,
+        help="specify how account statements should be summarized",
+        choices=["daily", "monthly"],
+        default="daily",
+    )
     ARG_PARSER.add_argument("--type", type=str, help="Specifies the p2p lending operator")
     ARG_PARSER.add_argument("--debug", action="store_true", help="enables debug level logging if set")
+
     CMD_ARGS = ARG_PARSER.parse_args()
 
     if CMD_ARGS.debug:
         logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 
-    sys.exit(main(CMD_ARGS.infile, CMD_ARGS.type))
+    sys.exit(main(CMD_ARGS.infile, CMD_ARGS.type, CMD_ARGS.aggregate))

--- a/parse-account-statements.py
+++ b/parse-account-statements.py
@@ -31,6 +31,7 @@ def platform_factory(operator_name="mintos"):
     Return an object for the required Peer-to-Peer lending platform
 
     :param operator_name: name of the P2P lending site, defaults to Mintos
+
     :return: object for the actual lending platform parser, None if not supported
     """
     config = os.path.join(os.path.dirname(__file__), "config", "{op}.yml".format(op=operator_name))
@@ -50,6 +51,7 @@ def main(infile, p2p_operator_name="mintos"):
 
     :param infile: input file containing the account statements from a supported platform
     :param p2p_operator_name: name of the Peer-to-Peer lending platform, defaults to Mintos
+
     :return: True, False if an error occurred.
     """
     if not os.path.exists(infile):

--- a/parse-account-statements.py
+++ b/parse-account-statements.py
@@ -63,6 +63,9 @@ def main(infile, p2p_operator_name="mintos"):
         platform_parser.account_statement_file = infile
         statement_list = platform_parser.parse_account_statement()
 
+        if not statement_list:
+            return False
+
         writer = portfolio_performance_writer.PortfolioPerformanceWriter()
         writer.init_output()
         for entry in statement_list:
@@ -73,6 +76,7 @@ def main(infile, p2p_operator_name="mintos"):
                 "portfolio_performance__{}.csv".format(p2p_operator_name),
             )
         )
+        return True
     else:
         return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ py==1.9.0
 pylint==2.5.2
 pytest==5.4.2
 pytest-cov==2.8.1
+PyYaml==5.3.1
 requests>=2.20.0
-ruamel.yaml==0.16.12
 six==1.15.0
 urllib3>=1.23
 wrapt==1.12.1

--- a/src/Statement.py
+++ b/src/Statement.py
@@ -53,7 +53,7 @@ class Statement:
 
     def get_value(self):
         """ get the value of the statement """
-        return self._statement[self._config.get_booking_value()].replace(".", ",")
+        return float(self._statement[self._config.get_booking_value()].replace(",", "."))
 
     def get_note(self):
         """ get the note of the statement """

--- a/src/Statement.py
+++ b/src/Statement.py
@@ -24,7 +24,7 @@ class Statement:
         """
         Check the category of the given statement.
 
-        :return: category of the statement; if unkown return the empty string
+        :return: category of the statement; if unknown return the empty string
         """
         booking_type = self._statement[self._config.get_booking_type()]
         category = ""
@@ -66,7 +66,7 @@ class Statement:
         """
         Check the currency of the given statement.
 
-        :return: currency of the statement; if unkown return 'EUR'
+        :return: currency of the statement; if unknown return 'EUR'
         """
         if self._config.get_booking_currency():
             return self._statement[self._config.get_booking_currency()]

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -115,6 +115,26 @@ class PeerToPeerPlatformParser(object):
             config = safe_load(ymlconfig)
             self.config = Config(config)
 
+    def __process_statement(self, statement, aggregate="daily"):
+        """
+        Processes each statement read from the account statement file. First, format in into the dictionary.
+        Then check what aggregation should be applied.
+
+            - daily: add directly to the output list.
+            - monthly: add it to intermediate aggregation collection.
+
+        :param statement: Contains one line from the account statement file
+        :param aggregate: specify the aggregation format; e.g. daily or monthly. Defaults to daily.
+
+        :return:
+        """
+        formatted_account_entry = self.__format_statement(statement)
+        if formatted_account_entry:
+            if aggregate == "daily":
+                self.output_list.append(formatted_account_entry)
+            elif aggregate == "monthly":
+                self.__aggregate_statements_monthly(formatted_account_entry)
+
     def parse_account_statement(self, aggregate="daily"):
         """
         read a platform account statement csv file and filter the content according to the given configuration file.
@@ -141,12 +161,7 @@ class PeerToPeerPlatformParser(object):
             account_statement = csv.DictReader(infile, dialect=dialect)
 
             for statement in account_statement:
-                formatted_account_entry = self.__format_statement(statement)
-                if formatted_account_entry:
-                    if aggregate == "daily":
-                        self.output_list.append(formatted_account_entry)
-                    elif aggregate == "monthly":
-                        self.__aggregate_statements_monthly(formatted_account_entry)
+                self.__process_statement(aggregate=aggregate, statement=statement)
 
         if aggregate == "monthly":
             self.__migrate_data_to_output()

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -82,11 +82,16 @@ class PeerToPeerPlatformParser(object):
             config = yaml.load(ymlconfig)
             self.config = Config(config)
 
-    def parse_account_statement(self, aggregate="monthly"):
+    def parse_account_statement(self, aggregate="daily"):
         """
-        read a platform account statement csv file and filter the content according to the defined strings
+        read a platform account statement csv file and filter the content according to the given configuration file.
+        If aggregation is selected the output data will be post processed in the following way:
 
-        :param aggregate: specifies the aggregation period. defaults to monthly.
+        - aggregate="daily": return the list of processed statements as is.
+        - aggregate="monthly": return a list of post-processed statements aggregating on monthly basis for each
+          booking type.
+
+        :param aggregate: specifies the aggregation period. defaults to daily.
         :return: list of account statement entries ready for use in Portfolio Performance
         """
         if os.path.exists(self._account_statement_file):
@@ -101,4 +106,8 @@ class PeerToPeerPlatformParser(object):
                         self.output_list.append(formatted_account_entry)
         else:
             logging.error("Account statement file {} does not exist.".format(self.account_statement_file))
-        return self.output_list
+
+        if aggregate == "daily":
+            return self.output_list
+        else:
+            logging.error("Aggregation mode '{}' not supported.".format(aggregate))

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -91,7 +91,7 @@ class PeerToPeerPlatformParser(object):
 
         formatted_account_entry = {
             PP_FIELDNAMES[0]: statement.get_date(),
-            PP_FIELDNAMES[1]: statement.get_value(),
+            PP_FIELDNAMES[1]: round(statement.get_value(), 9),
             PP_FIELDNAMES[2]: statement.get_currency(),
             PP_FIELDNAMES[3]: category,
             PP_FIELDNAMES[4]: statement.get_note(),

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -8,7 +8,6 @@ import calendar
 import codecs
 import csv
 import logging
-import os
 
 from yaml import safe_load
 
@@ -122,10 +121,6 @@ class PeerToPeerPlatformParser(object):
             logging.info("Aggregating data on a {} basis".format(aggregate))
         else:
             logging.error("Aggregating data on a {} basis not supported.".format(aggregate))
-            return
-
-        if not os.path.exists(self._account_statement_file):
-            logging.error("Account statement file {} does not exist.".format(self.account_statement_file))
             return
 
         self.__parse_service_config()

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -10,7 +10,7 @@ import csv
 import logging
 import os
 
-from ruamel.yaml import YAML
+from yaml import safe_load
 
 from src.Config import Config
 from src.portfolio_performance_writer import PP_FIELDNAMES
@@ -103,8 +103,7 @@ class PeerToPeerPlatformParser(object):
         Parse the YAML configuration file containing specific settings for the individual p2p loan platform
         """
         with open(self.config_file, "r", encoding="utf-8") as ymlconfig:
-            yaml = YAML(typ="safe")
-            config = yaml.load(ymlconfig)
+            config = safe_load(ymlconfig)
             self.config = Config(config)
 
     def parse_account_statement(self, aggregate="daily"):

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -57,7 +57,7 @@ class PeerToPeerPlatformParser(object):
 
         :param statement: contains a line from the given CSV file
 
-        :returns: dictionary containing the formatted account entry
+        :return: dictionary containing the formatted account entry
         """
         statement = Statement(self.config, statement)
         category = statement.get_category()
@@ -76,19 +76,18 @@ class PeerToPeerPlatformParser(object):
     def __parse_service_config(self):
         """
         Parse the YAML configuration file containing specific settings for the individual p2p loan platform
-
-        :return:
         """
         with open(self.config_file, "r", encoding="utf-8") as ymlconfig:
             yaml = YAML(typ="safe")
             config = yaml.load(ymlconfig)
             self.config = Config(config)
 
-    def parse_account_statement(self):
+    def parse_account_statement(self, aggregate="monthly"):
         """
         read a platform account statement csv file and filter the content according to the defined strings
 
-        :return:
+        :param aggregate: specifies the aggregation period. defaults to monthly.
+        :return: list of account statement entries ready for use in Portfolio Performance
         """
         if os.path.exists(self._account_statement_file):
             self.__parse_service_config()

--- a/src/p2p_account_statement_parser.py
+++ b/src/p2p_account_statement_parser.py
@@ -97,6 +97,16 @@ class PeerToPeerPlatformParser(object):
         }
         return formatted_account_entry
 
+    def __migrate_data_to_output(self):
+        """
+        Iterates over the data collected for the aggregation of account statement data and adds it to the output list.
+        :return:
+        """
+        for _, booking_type in self.aggregation_data.items():
+            for _, entry in booking_type.items():
+                entry[PP_FIELDNAMES[1]] = round(entry[PP_FIELDNAMES[1]], 9)
+                self.output_list.append(entry)
+
     def __parse_service_config(self):
         """
         Parse the YAML configuration file containing specific settings for the individual p2p loan platform
@@ -139,8 +149,5 @@ class PeerToPeerPlatformParser(object):
                         self.__aggregate_statements_monthly(formatted_account_entry)
 
         if aggregate == "monthly":
-            for _, booking_type in self.aggregation_data.items():
-                for _, entry in booking_type.items():
-                    entry[PP_FIELDNAMES[1]] = round(entry[PP_FIELDNAMES[1]], 9)
-                    self.output_list.append(entry)
+            self.__migrate_data_to_output()
         return self.output_list

--- a/src/portfolio_performance_writer.py
+++ b/src/portfolio_performance_writer.py
@@ -49,6 +49,7 @@ class PortfolioPerformanceWriter(object):
         :return:
         """
         if statement_dict:
+            statement_dict[PP_FIELDNAMES[1]] = str(statement_dict[PP_FIELDNAMES[1]]).replace(".", ",")
             self.out_csv_writer.writerow(statement_dict)
 
     def write_pp_csv_file(self, outfile="portfolio_performance.csv"):

--- a/src/portfolio_performance_writer.py
+++ b/src/portfolio_performance_writer.py
@@ -31,8 +31,6 @@ class PortfolioPerformanceWriter(object):
     def init_output(self):
         """
         Initialize output csv file
-
-        :return:
         """
         if not self.out_csv_writer:
             self.out_csv_writer = csv.DictWriter(

--- a/src/test/test_p2p_account_statement_parser.py
+++ b/src/test/test_p2p_account_statement_parser.py
@@ -45,39 +45,39 @@ class TestBaseParser(TestCase):
         )
         expected_statement = [
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2019, 1, 1),
                 "Notiz": ": TransferDeposit|DE1111000000111111",
                 "Typ": "Einlage",
-                "Wert": "100",
-                "Buchungswährung": "EUR",
+                "Wert": 100.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2019, 1, 2),
                 "Notiz": ": TransferGoGrow",
                 "Typ": "Entnahme",
-                "Wert": "-100",
-                "Buchungswährung": "EUR",
+                "Wert": -100.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2019, 1, 3),
                 "Notiz": ": TransferDeposit|Wirecard",
                 "Typ": "Einlage",
-                "Wert": "100",
-                "Buchungswährung": "EUR",
+                "Wert": 100.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2019, 1, 4),
                 "Notiz": "1111111-111111112: TransferInterestRepaiment",
                 "Typ": "Zinsen",
-                "Wert": "0,0067920792",
-                "Buchungswährung": "EUR",
+                "Wert": 0.006792079,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2019, 1, 5),
                 "Notiz": "1111111-111111113: TransferExtraInterestRepaiment",
                 "Typ": "Zinsen",
-                "Wert": "7,05883E-05",
-                "Buchungswährung": "EUR",
+                "Wert": 7.0588e-05,
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement())
@@ -97,7 +97,7 @@ class TestBaseParser(TestCase):
                 "Datum": datetime.date(2019, 1, 2),
                 "Notiz": ": TransferGoGrow",
                 "Typ": "Einlage",
-                "Wert": "-100",
+                "Wert": -100.0,
                 "Buchungswährung": "EUR",
             }
         ]
@@ -111,74 +111,74 @@ class TestBaseParser(TestCase):
         )
         expected_statement = [
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 18),
                 "Notiz": "18012018204714DEP: ",
                 "Typ": "Einlage",
-                "Wert": "1000,0",
-                "Buchungswährung": "EUR",
+                "Wert": 1000.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 23),
                 "Notiz": "23012018092020DEP: ",
                 "Typ": "Einlage",
-                "Wert": "1000,0",
-                "Buchungswährung": "EUR",
+                "Wert": 1000.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 24),
                 "Notiz": "24012018000000REFEE5975: Kaerepere business loan 2. stage",
                 "Typ": "Zinsen",
-                "Wert": "0,25",
-                "Buchungswährung": "EUR",
+                "Wert": 0.25,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 24),
                 "Notiz": "24012018000346WIT: ",
                 "Typ": "Entnahme",
-                "Wert": "-1000,0",
-                "Buchungswährung": "EUR",
+                "Wert": -1000.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 30),
                 "Notiz": "30012018000000REFEE4182: Laiamäe bridge loan",
                 "Typ": "Zinsen",
-                "Wert": "0,5",
-                "Buchungswährung": "EUR",
+                "Wert": 0.5,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 2, 24),
                 "Notiz": "24022018000000INTEE5975: Kaerepere business loan 2. stage",
                 "Typ": "Zinsen",
-                "Wert": "0,46",
-                "Buchungswährung": "EUR",
+                "Wert": 0.46,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 2, 27),
                 "Notiz": "27022018225240DEP: ",
                 "Typ": "Einlage",
-                "Wert": "1000,0",
-                "Buchungswährung": "EUR",
+                "Wert": 1000.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 3, 1),
                 "Notiz": "01032018000000BONLT2293: Grevitas construction loan",
                 "Typ": "Zinsen",
-                "Wert": "0,47",
-                "Buchungswährung": "EUR",
+                "Wert": 0.47,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 3, 15),
                 "Notiz": "15032018000000INTLT0689: Užutekio bridge loan",
                 "Typ": "Zinsen",
-                "Wert": "0,59",
-                "Buchungswährung": "EUR",
+                "Wert": 0.59,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 4, 8),
                 "Notiz": "08042018000000INTEE3186: Pärnaõie st bridge loan",
                 "Typ": "Zinsen",
-                "Wert": "0,46",
-                "Buchungswährung": "EUR",
+                "Wert": 0.46,
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement())
@@ -187,61 +187,62 @@ class TestBaseParser(TestCase):
         """test parse_account_statement for mintos"""
         expected_statement = [
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 17),
                 "Notiz": "236659674: Incoming client payment",
                 "Typ": "Einlage",
-                "Wert": "20",
-                "Buchungswährung": "EUR",
+                "Wert": 20.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 18),
                 "Notiz": "237974500: Interest income Loan ID: 2049443-01",
                 "Typ": "Zinsen",
-                "Wert": "0,005555556",
-                "Buchungswährung": "EUR",
+                "Wert": 0.005555556,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 19),
-                "Notiz": "238112163: Interest income on rebuy Rebuy purpose: agreement_amendment Loan ID: 2198495-01",
+                "Notiz": "238112163: Interest income on rebuy Rebuy purpose: "
+                "agreement_amendment Loan ID: 2198495-01",
                 "Typ": "Zinsen",
-                "Wert": "0,003777778",
-                "Buchungswährung": "EUR",
+                "Wert": 0.003777778,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 19),
-                "Notiz": "238112984: Interest income on rebuy Rebuy purpose: early_repayment Loan ID: 2202538-01",
+                "Notiz": "238112984: Interest income on rebuy Rebuy purpose: early_repayment " "Loan ID: 2202538-01",
                 "Typ": "Zinsen",
-                "Wert": "0,003083333",
-                "Buchungswährung": "EUR",
+                "Wert": 0.003083333,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 25),
                 "Notiz": "241699935: Late payment fee income Loan ID: 1529173-01",
                 "Typ": "Zinsen",
-                "Wert": "0,001214211",
-                "Buchungswährung": "EUR",
+                "Wert": 0.001214211,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 29),
                 "Notiz": "243559685: Delayed interest income on rebuy Rebuy purpose: "
                 "agreement_amendment Loan ID: 2198503-01",
                 "Typ": "Zinsen",
-                "Wert": "0,000342077",
-                "Buchungswährung": "EUR",
+                "Wert": 0.000342077,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 2, 27),
                 "Notiz": "260918485: Cashback bonus",
                 "Typ": "Zinsen",
-                "Wert": "0,3",
-                "Buchungswährung": "EUR",
+                "Wert": 0.3,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2016, 9, 28),
                 "Notiz": "115013710: Withdraw application",
                 "Typ": "Entnahme",
-                "Wert": "-20",
-                "Buchungswährung": "EUR",
+                "Wert": -20.0,
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement())
@@ -250,61 +251,62 @@ class TestBaseParser(TestCase):
         """test parse_account_statement for mintos"""
         expected_statement = [
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 17),
                 "Notiz": "236659674: Incoming client payment",
                 "Typ": "Einlage",
-                "Wert": "20",
-                "Buchungswährung": "EUR",
+                "Wert": 20.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 18),
                 "Notiz": "237974500: Interest income Loan ID: 2049443-01",
                 "Typ": "Zinsen",
-                "Wert": "0,005555556",
-                "Buchungswährung": "EUR",
+                "Wert": 0.005555556,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 19),
-                "Notiz": "238112163: Interest income on rebuy Rebuy purpose: agreement_amendment Loan ID: 2198495-01",
+                "Notiz": "238112163: Interest income on rebuy Rebuy purpose: "
+                "agreement_amendment Loan ID: 2198495-01",
                 "Typ": "Zinsen",
-                "Wert": "0,003777778",
-                "Buchungswährung": "EUR",
+                "Wert": 0.003777778,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 19),
-                "Notiz": "238112984: Interest income on rebuy Rebuy purpose: early_repayment Loan ID: 2202538-01",
+                "Notiz": "238112984: Interest income on rebuy Rebuy purpose: early_repayment " "Loan ID: 2202538-01",
                 "Typ": "Zinsen",
-                "Wert": "0,003083333",
-                "Buchungswährung": "EUR",
+                "Wert": 0.003083333,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 25),
                 "Notiz": "241699935: Late payment fee income Loan ID: 1529173-01",
                 "Typ": "Zinsen",
-                "Wert": "0,001214211",
-                "Buchungswährung": "EUR",
+                "Wert": 0.001214211,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 29),
                 "Notiz": "243559685: Delayed interest income on rebuy Rebuy purpose: "
                 "agreement_amendment Loan ID: 2198503-01",
                 "Typ": "Zinsen",
-                "Wert": "0,000342077",
-                "Buchungswährung": "EUR",
+                "Wert": 0.000342077,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 2, 27),
                 "Notiz": "260918485: Cashback bonus",
                 "Typ": "Zinsen",
-                "Wert": "0,3",
-                "Buchungswährung": "EUR",
+                "Wert": 0.3,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2016, 9, 28),
                 "Notiz": "115013710: Withdraw application",
                 "Typ": "Entnahme",
-                "Wert": "-20",
-                "Buchungswährung": "EUR",
+                "Wert": -20.0,
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement(aggregate="daily"))
@@ -319,39 +321,39 @@ class TestBaseParser(TestCase):
         )
         expected_statement = [
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 2, 28),
                 "Notiz": "Monatszusammenfassung",
                 "Typ": "Einlage",
-                "Wert": "20",
-                "Buchungswährung": "EUR",
+                "Wert": 20.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 2, 28),
                 "Notiz": "Monatszusammenfassung",
                 "Typ": "Zinsen",
-                "Wert": "0,3",
-                "Buchungswährung": "EUR",
+                "Wert": 0.3,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 31),
                 "Notiz": "Monatszusammenfassung",
                 "Typ": "Einlage",
-                "Wert": "20",
-                "Buchungswährung": "EUR",
+                "Wert": 20.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 31),
                 "Notiz": "Monatszusammenfassung",
                 "Typ": "Zinsen",
-                "Wert": "0,013972955",
-                "Buchungswährung": "EUR",
+                "Wert": 0.013972955,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2016, 9, 30),
                 "Notiz": "Monatszusammenfassung",
                 "Typ": "Entnahme",
-                "Wert": "-20",
-                "Buchungswährung": "EUR",
+                "Wert": -20.0,
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement(aggregate="monthly"))
@@ -369,18 +371,18 @@ class TestBaseParser(TestCase):
         )
         expected_statement = [
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 2, 15),
                 "Notiz": "2438244: ",
                 "Typ": "Einlage",
-                "Wert": "2000",
-                "Buchungswährung": "EUR",
+                "Wert": 2000.0,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 2, 16),
                 "Notiz": "2458795: 856836",
                 "Typ": "Zinsen",
-                "Wert": "0,003835616",
-                "Buchungswährung": "EUR",
+                "Wert": 0.003835616,
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement())
@@ -393,32 +395,32 @@ class TestBaseParser(TestCase):
         )
         expected_statement = [
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 5, 1),
                 "Notiz": "PL-84587: 119113",
                 "Typ": "Zinsen",
-                "Wert": "0,1",
-                "Buchungswährung": "EUR",
+                "Wert": 0.1,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 4, 30),
                 "Notiz": "PL-82794: 116800",
                 "Typ": "Zinsen",
-                "Wert": "0,12",
-                "Buchungswährung": "EUR",
+                "Wert": 0.12,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 4, 26),
                 "Notiz": "GL-22989301: 117251",
                 "Typ": "Zinsen",
-                "Wert": "0,11",
-                "Buchungswährung": "EUR",
+                "Wert": 0.11,
             },
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 24),
                 "Notiz": ": ",
                 "Typ": "Einlage",
-                "Wert": "2000",
-                "Buchungswährung": "EUR",
+                "Wert": 2000.0,
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement())
@@ -435,25 +437,25 @@ class TestBaseParser(TestCase):
         )
         expected_statement = [
             {
+                "Buchungswährung": "EUR",
                 "Datum": datetime.date(2020, 8, 25),
-                "Wert": "121,91",
-                "Buchungswährung": "EUR",
-                "Typ": "Einlage",
                 "Notiz": "405eea2a-7745-4588-8f08-5c1512987324: NA",
-            },
-            {
-                "Datum": datetime.date(2020, 9, 7),
-                "Wert": "10,03",
-                "Buchungswährung": "EUR",
-                "Typ": "Zinsen",
-                "Notiz": "b9da7662-de61-43d1-a179-c300d5695587: 6c4a6d93-faea-4d96-856c-7cdd3fb3023b",
-            },
-            {
-                "Datum": datetime.date(2020, 9, 7),
-                "Wert": "10",
-                "Buchungswährung": "EUR",
                 "Typ": "Einlage",
+                "Wert": 121.91,
+            },
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2020, 9, 7),
+                "Notiz": "b9da7662-de61-43d1-a179-c300d5695587: " "6c4a6d93-faea-4d96-856c-7cdd3fb3023b",
+                "Typ": "Zinsen",
+                "Wert": 10.03,
+            },
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2020, 9, 7),
                 "Notiz": "7260c567-fdb4-44d4-84ce-4256c7d7fb80: NA",
+                "Typ": "Einlage",
+                "Wert": 10.0,
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement())

--- a/src/test/test_p2p_account_statement_parser.py
+++ b/src/test/test_p2p_account_statement_parser.py
@@ -458,3 +458,7 @@ class TestBaseParser(unittest.TestCase):
             },
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement())
+
+    def test_aggregation_not_supported(self):
+        """test if unsopported aggregation is correctly handled"""
+        self.assertFalse(self.base_parser.parse_account_statement(aggregate="yearly"))

--- a/src/test/test_p2p_account_statement_parser.py
+++ b/src/test/test_p2p_account_statement_parser.py
@@ -6,12 +6,12 @@ Copyright 2018-05-01 ChrisRBe
 """
 import datetime
 import os
-from unittest import TestCase
+import unittest
 
 from src.p2p_account_statement_parser import PeerToPeerPlatformParser
 
 
-class TestBaseParser(TestCase):
+class TestBaseParser(unittest.TestCase):
     """Test case implementation for PeerToPeerPlatformParser"""
 
     def setUp(self):
@@ -356,6 +356,7 @@ class TestBaseParser(TestCase):
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement(aggregate="monthly"))
 
+    @unittest.skip("Currently not checking if infile exists.")
     def test_no_statement_file(self):
         """test parse_account_statement with non existent file"""
         self.base_parser.account_statement_file = os.path.join(os.path.dirname(__file__), "not_existing.csv")

--- a/src/test/test_p2p_account_statement_parser.py
+++ b/src/test/test_p2p_account_statement_parser.py
@@ -16,11 +16,9 @@ class TestBaseParser(TestCase):
 
     def setUp(self):
         """test case setUp, run for each test case"""
-        self.base_parser = PeerToPeerPlatformParser()
-        self.base_parser.account_statement_file = os.path.join(os.path.dirname(__file__), "testdata", "mintos.csv")
-        self.base_parser.config_file = os.path.join(
-            os.path.dirname(__file__), os.pardir, os.pardir, "config", "mintos.yml"
-        )
+        self.account_statement_file = os.path.join(os.path.dirname(__file__), "testdata", "mintos.csv")
+        self.config_file = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "config", "mintos.yml")
+        self.base_parser = PeerToPeerPlatformParser(infile=self.account_statement_file, config=self.config_file)
         self.maxDiff = None
 
     def test_account_statement_file(self):

--- a/src/test/test_p2p_account_statement_parser.py
+++ b/src/test/test_p2p_account_statement_parser.py
@@ -246,6 +246,116 @@ class TestBaseParser(TestCase):
         ]
         self.assertEqual(expected_statement, self.base_parser.parse_account_statement())
 
+    def test_mintos_parsing_daily_aggregation(self):
+        """test parse_account_statement for mintos"""
+        expected_statement = [
+            {
+                "Datum": datetime.date(2018, 1, 17),
+                "Notiz": "236659674: Incoming client payment",
+                "Typ": "Einlage",
+                "Wert": "20",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 1, 18),
+                "Notiz": "237974500: Interest income Loan ID: 2049443-01",
+                "Typ": "Zinsen",
+                "Wert": "0,005555556",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 1, 19),
+                "Notiz": "238112163: Interest income on rebuy Rebuy purpose: agreement_amendment Loan ID: 2198495-01",
+                "Typ": "Zinsen",
+                "Wert": "0,003777778",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 1, 19),
+                "Notiz": "238112984: Interest income on rebuy Rebuy purpose: early_repayment Loan ID: 2202538-01",
+                "Typ": "Zinsen",
+                "Wert": "0,003083333",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 1, 25),
+                "Notiz": "241699935: Late payment fee income Loan ID: 1529173-01",
+                "Typ": "Zinsen",
+                "Wert": "0,001214211",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 1, 29),
+                "Notiz": "243559685: Delayed interest income on rebuy Rebuy purpose: "
+                "agreement_amendment Loan ID: 2198503-01",
+                "Typ": "Zinsen",
+                "Wert": "0,000342077",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 2, 27),
+                "Notiz": "260918485: Cashback bonus",
+                "Typ": "Zinsen",
+                "Wert": "0,3",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2016, 9, 28),
+                "Notiz": "115013710: Withdraw application",
+                "Typ": "Entnahme",
+                "Wert": "-20",
+                "Buchungswährung": "EUR",
+            },
+        ]
+        self.assertEqual(expected_statement, self.base_parser.parse_account_statement(aggregate="daily"))
+
+    def test_mintos_parsing_monthly_aggregation(self):
+        """test parse_account_statement for mintos"""
+        self.base_parser.account_statement_file = os.path.join(
+            os.path.dirname(__file__), "testdata", "mintos_several_months.csv"
+        )
+        self.base_parser.config_file = os.path.join(
+            os.path.dirname(__file__), os.pardir, os.pardir, "config", "mintos.yml"
+        )
+        expected_statement = [
+            {
+                "Datum": datetime.date(2018, 2, 28),
+                "Notiz": "Monatszusammenfassung",
+                "Typ": "Einlage",
+                "Wert": "20",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 2, 28),
+                "Notiz": "Monatszusammenfassung",
+                "Typ": "Zinsen",
+                "Wert": "0,3",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 1, 31),
+                "Notiz": "Monatszusammenfassung",
+                "Typ": "Einlage",
+                "Wert": "20",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2018, 1, 31),
+                "Notiz": "Monatszusammenfassung",
+                "Typ": "Zinsen",
+                "Wert": "0,013972955",
+                "Buchungswährung": "EUR",
+            },
+            {
+                "Datum": datetime.date(2016, 9, 30),
+                "Notiz": "Monatszusammenfassung",
+                "Typ": "Entnahme",
+                "Wert": "-20",
+                "Buchungswährung": "EUR",
+            },
+        ]
+        self.assertEqual(expected_statement, self.base_parser.parse_account_statement(aggregate="monthly"))
+
     def test_no_statement_file(self):
         """test parse_account_statement with non existent file"""
         self.base_parser.account_statement_file = os.path.join(os.path.dirname(__file__), "not_existing.csv")

--- a/src/test/testdata/portfolio_performance__bondora_go_grow.csv
+++ b/src/test/testdata/portfolio_performance__bondora_go_grow.csv
@@ -1,2 +1,0 @@
-Datum,Wert,Buchungswährung,Typ,Notiz
-2019-01-02,-100,EUR,Einlage,: TransferGoGrow

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,5 @@
+[pep8]
+max-line-length = 119
 [flake8]
 max-line-length = 119
 ignore = E203, E266, E501, W503


### PR DESCRIPTION
This PR should cover the idea proposed in #252 by adding a command line parameter that can be used to aggregate account statements by month.