### PR TITLE
Add real daily aggregation, fix small numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ List of currently supported providers:
     - Debitum Network
 
 Control the way how account statements are processed via the aggregate parameter:
-    - daily: Currently does not process the input data beyond making it Portfolio Performance compatible.
+    - transaction: Currently does not process the input data beyond making it Portfolio Performance compatible.
+    - daily: This aggregates all bookings of the same type into one statement per type and day.
     - monthly: This aggregates all bookings of the same type into one statement per type and month. Sets
             the last day of the month as transaction date.
 
-Default behaviour for now is 'daily'.
+Default behaviour for now is 'transaction'.
 
 Copyright 2018-03-17 ChrisRBe
 
@@ -48,7 +49,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --aggregate {daily,monthly}
+  --aggregate {transaction,daily,monthly}
                         specify how account statements should be summarized
   --type TYPE           Specifies the p2p lending operator
   --debug               enables debug level logging if set

--- a/parse-account-statements.py
+++ b/parse-account-statements.py
@@ -16,11 +16,12 @@ List of currently supported providers:
     - Debitum Network
 
 Control the way how account statements are processed via the aggregate parameter:
-    - daily: Currently does not process the input data beyond making it Portfolio Performance compatible.
+    - transaction: Currently does not process the input data beyond making it Portfolio Performance compatible.
+    - daily: This aggregates all bookings of the same type into one statement per type and day.
     - monthly: This aggregates all bookings of the same type into one statement per type and month. Sets
             the last day of the month as transaction date.
 
-Default behaviour for now is 'daily'.
+Default behaviour for now is 'transaction'.
 
 Copyright 2018-03-17 ChrisRBe
 """
@@ -50,14 +51,14 @@ def platform_factory(infile, operator_name="mintos"):
         return None
 
 
-def main(infile, p2p_operator_name="mintos", aggregate="daily"):
+def main(infile, p2p_operator_name="mintos", aggregate="transaction"):
     """
     Processes the provided input file with the rules defined for the given platform.
     Outputs a CSV file readable by Portfolio Performance
 
     :param infile: input file containing the account statements from a supported platform
     :param p2p_operator_name: name of the Peer-to-Peer lending platform, defaults to Mintos
-    :param aggregate: specifies the aggregation period. defaults to daily.
+    :param aggregate: specifies the aggregation period. defaults to transaction.
 
     :return: True, False if an error occurred.
     """
@@ -100,8 +101,8 @@ if __name__ == "__main__":
         "--aggregate",
         type=str,
         help="specify how account statements should be summarized",
-        choices=["daily", "monthly"],
-        default="daily",
+        choices=["transaction", "daily", "monthly"],
+        default="transaction",
     )
     ARG_PARSER.add_argument("--type", type=str, help="Specifies the p2p lending operator")
     ARG_PARSER.add_argument("--debug", action="store_true", help="enables debug level logging if set")

--- a/src/portfolio_performance_writer.py
+++ b/src/portfolio_performance_writer.py
@@ -49,7 +49,7 @@ class PortfolioPerformanceWriter(object):
         :return:
         """
         if statement_dict:
-            statement_dict[PP_FIELDNAMES[1]] = str(statement_dict[PP_FIELDNAMES[1]]).replace(".", ",")
+            statement_dict[PP_FIELDNAMES[1]] = "{0:.9f}".format(statement_dict[PP_FIELDNAMES[1]]).replace(".", ",")
             self.out_csv_writer.writerow(statement_dict)
 
     def write_pp_csv_file(self, outfile="portfolio_performance.csv"):

--- a/src/test/test_p2p_account_statement_parser.py
+++ b/src/test/test_p2p_account_statement_parser.py
@@ -307,7 +307,7 @@ class TestBaseParser(unittest.TestCase):
                 "Wert": -20.0,
             },
         ]
-        self.assertEqual(expected_statement, self.base_parser.parse_account_statement(aggregate="daily"))
+        self.assertEqual(expected_statement, self.base_parser.parse_account_statement(aggregate="transaction"))
 
     def test_mintos_parsing_monthly_aggregation(self):
         """test parse_account_statement for mintos"""

--- a/src/test/test_p2p_account_statement_parser.py
+++ b/src/test/test_p2p_account_statement_parser.py
@@ -251,6 +251,61 @@ class TestBaseParser(unittest.TestCase):
             {
                 "Buchungswährung": "EUR",
                 "Datum": datetime.date(2018, 1, 17),
+                "Notiz": "Tageszusammenfassung",
+                "Typ": "Einlage",
+                "Wert": 20.0,
+            },
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2018, 1, 18),
+                "Notiz": "Tageszusammenfassung",
+                "Typ": "Zinsen",
+                "Wert": 0.005555556,
+            },
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2018, 1, 19),
+                "Notiz": "Tageszusammenfassung",
+                "Typ": "Zinsen",
+                "Wert": 0.006861111,
+            },
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2018, 1, 25),
+                "Notiz": "Tageszusammenfassung",
+                "Typ": "Zinsen",
+                "Wert": 0.001214211,
+            },
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2018, 1, 29),
+                "Notiz": "Tageszusammenfassung",
+                "Typ": "Zinsen",
+                "Wert": 0.000342077,
+            },
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2018, 2, 27),
+                "Notiz": "Tageszusammenfassung",
+                "Typ": "Zinsen",
+                "Wert": 0.3,
+            },
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2016, 9, 28),
+                "Notiz": "Tageszusammenfassung",
+                "Typ": "Entnahme",
+                "Wert": -20.0,
+            },
+        ]
+        self.assertEqual(expected_statement, self.base_parser.parse_account_statement(aggregate="daily"))
+
+    def test_mintos_parsing_transaction_aggregation(self):
+        """test parse_account_statement for mintos"""
+        expected_statement = [
+            {
+                "Buchungswährung": "EUR",
+                "Datum": datetime.date(2018, 1, 17),
                 "Notiz": "236659674: Incoming client payment",
                 "Typ": "Einlage",
                 "Wert": 20.0,

--- a/src/test/test_portfolio_performance_writer.py
+++ b/src/test/test_portfolio_performance_writer.py
@@ -36,7 +36,7 @@ class TestPortfolioPerformanceWriter(TestCase):
         }
         self.pp_writer.update_output(test_entry)
         self.assertEqual(
-            "Datum,Wert,Buchungswährung,Typ,Notiz\r\ndate,\"0,00000000\",currency,category,note",
+            'Datum,Wert,Buchungswährung,Typ,Notiz\r\ndate,"0,00000000",currency,category,note',
             self.pp_writer.out_string_stream.getvalue().strip(),
         )
 
@@ -51,7 +51,7 @@ class TestPortfolioPerformanceWriter(TestCase):
         }
         self.pp_writer.update_output(test_entry)
         self.assertEqual(
-            "Datum,Wert,Buchungswährung,Typ,Notiz\r\n" "date,\"0,00000000\",currency,category,Laiamäe Pärnaõie Užutekio",
+            'Datum,Wert,Buchungswährung,Typ,Notiz\r\ndate,"0,00000000",currency,category,Laiamäe Pärnaõie Užutekio',
             self.pp_writer.out_string_stream.getvalue().strip(),
         )
 

--- a/src/test/test_portfolio_performance_writer.py
+++ b/src/test/test_portfolio_performance_writer.py
@@ -29,14 +29,14 @@ class TestPortfolioPerformanceWriter(TestCase):
         """test update_output"""
         test_entry = {
             PP_FIELDNAMES[0]: "date",
-            PP_FIELDNAMES[1]: "profit",
+            PP_FIELDNAMES[1]: 0,
             PP_FIELDNAMES[2]: "currency",
             PP_FIELDNAMES[3]: "category",
             PP_FIELDNAMES[4]: "note",
         }
         self.pp_writer.update_output(test_entry)
         self.assertEqual(
-            "Datum,Wert,Buchungswährung,Typ,Notiz\r\ndate,profit,currency,category,note",
+            "Datum,Wert,Buchungswährung,Typ,Notiz\r\ndate,\"0,00000000\",currency,category,note",
             self.pp_writer.out_string_stream.getvalue().strip(),
         )
 
@@ -44,14 +44,14 @@ class TestPortfolioPerformanceWriter(TestCase):
         """test update_output with umlauts"""
         test_entry = {
             PP_FIELDNAMES[0]: "date",
-            PP_FIELDNAMES[1]: "profit",
+            PP_FIELDNAMES[1]: 0,
             PP_FIELDNAMES[2]: "currency",
             PP_FIELDNAMES[3]: "category",
             PP_FIELDNAMES[4]: "Laiamäe Pärnaõie Užutekio",
         }
         self.pp_writer.update_output(test_entry)
         self.assertEqual(
-            "Datum,Wert,Buchungswährung,Typ,Notiz\r\n" "date,profit,currency,category,Laiamäe Pärnaõie Užutekio",
+            "Datum,Wert,Buchungswährung,Typ,Notiz\r\n" "date,\"0,00000000\",currency,category,Laiamäe Pärnaõie Užutekio",
             self.pp_writer.out_string_stream.getvalue().strip(),
         )
 


### PR DESCRIPTION
Hi @ChrisRBe,

vielen Dank noch einmal für den tollen Parser. Ich habe eine neue Aggregation hinzugefügt. Damit heisst die alte "daily" aggregation jetzt "transaction", da jede Transaktion 1:1 übernommen wird, und die neue "daily" erzeugt pro Transaktionstyp und Tag einen Eintrag.

Weiterhin habe ich mit einem `str.format` versucht das richtige Format sehr kleiner Zahlen sicherzustellen, da manchmal das wissenschaftliche Format (z.B. "1,247e-06") in die CSV geschrieben wurde, und Portfolio Performance damit ein Problem hat.