### PR TITLE
chore: drop python 3.6 support

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,2 +1,2 @@
-status = ["build (3.6)", "build (3.7)", "build (3.8)", "build (3.9)", "build (3.10)"]
+status = ["build (3.7)", "build (3.8)", "build (3.9)", "build (3.10)"]
 delete_merged_branches = true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.6 reached end of life at the end of 2021. 

The actual script should still run, but some components required for the devenv no longer support Python 3.6.