### PR TITLE
distinguish transfers between main and Go&Grow accounts

### DIFF
--- a/config/bondora.yml
+++ b/config/bondora.yml
@@ -1,7 +1,7 @@
 ---
 type_regex: !!map
-  deposit: "(^TransferDeposit.*)"
-  withdraw: "(^Withdraw.*)|(^TransferGoGrow.*)"
+  deposit: "(^TransferDeposit.*)|(^TransferGoGrowMainRepaiment.*)"
+  withdraw: "(^Withdraw.*)|(^TransferGoGrow$)"
   interest: "(^TransferInterestRepaiment.*)|(^TransferExtraInterestRepaiment.*)"
   fee: "(^FX commission.*)"
 

--- a/config/bondora_go_grow.yml
+++ b/config/bondora_go_grow.yml
@@ -1,7 +1,7 @@
 ---
 type_regex: !!map
-  deposit: "(^TransferGoGrow.*)"
-  withdraw: "(^$)"
+  deposit: "(^TransferGoGrow$)"
+  withdraw: "(^TransferGoGrowMainRepaiment$)"
   interest: "(^$)"
   fee: "(^$)"
 


### PR DESCRIPTION
To make sure that the transfers between Bondora main account and the Go&Grow account, the parsing needs to be refined.